### PR TITLE
Enable native linking for WASM

### DIFF
--- a/src/SuperJMN.Site.Browser/SuperJMN.Site.Browser.csproj
+++ b/src/SuperJMN.Site.Browser/SuperJMN.Site.Browser.csproj
@@ -3,6 +3,7 @@
         <TargetFramework>net8.0-browser</TargetFramework>
         <OutputType>Exe</OutputType>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <WasmBuildNative>true</WasmBuildNative>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- link native libraries in browser project

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689135d9ed4c832fbaacc0a827d3fabd